### PR TITLE
Revert to BAP v1.6 for the time being

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,10 +35,9 @@ RUN sudo apt-get -y update \
     && yes /usr/local/bin | sudo sh install.sh \
     # install bap
     && opam init --auto-setup --comp=4.05.0 --disable-sandboxing --yes \
-    && opam repo add bap git://github.com/BinaryAnalysisPlatform/opam-repository#testing \
     && opam update \
     && opam install depext --yes \
-    && OPAMJOBS=1 opam depext --install bap --yes \
+    && OPAMJOBS=1 opam depext --install bap.1.6.0 --yes \
     && OPAMJOBS=1 opam install yojson alcotest dune core ppx_deriving_yojson --yes
 
 WORKDIR /home/bap/cwe_checker/src

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # cwe_checker_travis_docker_image
-Docker image with current BAP (opam testing) and other dependencies for fast testing of cwe_checker on travis
+Docker image with BAP version 1.6 and other dependencies for fast testing of cwe_checker on travis


### PR DESCRIPTION
Since BAP v2.0 testing is under way on the BAP master branch, we should use the stable BAP v1.6 until we are ready to switch to 2.0.

Also, shouldn't I have access to this repo?